### PR TITLE
mysqlproxy: expose stmt id for prepared statements

### DIFF
--- a/client/stmt.go
+++ b/client/stmt.go
@@ -31,6 +31,10 @@ func (s *Stmt) WarningsNum() int {
 	return s.warnings
 }
 
+func (s *Stmt) ID() uint32 {
+	return s.id
+}
+
 func (s *Stmt) Execute(args ...interface{}) (*Result, error) {
 	if err := s.write(args...); err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
This commit exposes the stmt id to keep track of for prepared statementes so that we can close the right statements in later steps.