### PR TITLE
server: do not use hack.String for Query

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -102,7 +102,7 @@ func (c *Conn) Dispatch(data []byte) interface{} {
 		c.stmtID++
 		st := new(Stmt)
 		st.ID = c.stmtID
-		st.Query = hack.String(data)
+		st.Query = string(data)
 		var err error
 		if st.Params, st.Columns, st.Context, err = c.h.HandleStmtPrepare(st.Query); err != nil {
 			return err


### PR DESCRIPTION
If we plan on re-using a buffer for commands, we need to make a copy of the query when we do handleStmtPrepare. Otherwise, this value is subject to be overridden.